### PR TITLE
Fixed typo in path name snapdrived -> snapdrive

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,5 @@
 class snapdrived::config {
-  file { '/opt/NetApp/snapdrived/snapdrive.conf':
+  file { '/opt/NetApp/snapdrive/snapdrive.conf':
     content => template('snapdrived/snapdrive.conf.erb'),
     mode    => '0644',
   }


### PR DESCRIPTION
the config file should go into /opt/NetApp/snapdrive, not /opt/NetApp/snapdrived.  Module currently fails to run because the parent dir of the config file doesn't exist.
