### PR TITLE
Refactor of module

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,0 @@
-class snapdrived::config {
-  file { '/opt/NetApp/snapdrive/snapdrive.conf':
-    content => template('snapdrived/snapdrive.conf.erb'),
-    mode    => '0644',
-  }
-}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,5 @@
 class snapdrived::config {
-  file { '/opt/NetApp/snapdrived/snapdrive.conf':
+  file { '/opt/NetApp/snapdrive/snapdrive.conf':
     content => template('snapdrived/snapdrive.conf.erb'),
     mode    => '0644',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,14 +122,7 @@ class snapdrived (
   $volume_destroy_retry                      = undef,
   $volume_destroy_retry_sleep                = undef,
   $volume_offline_retry                      = undef,
-  $audit_log_file                            = undef,
-  $trace_log_file                            = undef,
-  $recovery_log_file                         = undef,
-  $client_trace_log_file                     = undef,
-  $daemon_trace_log_file                     = undef,
-  $ping_interfaces_with_same_octet           = undef,
-  $check_export_permission_nfs_clone         = undef,
-  $snapcreate_check_nonpersistent_nfs        = undef,
+  $volume_offline_retry_sleep                = undef,
 ){
 
   package { 'netapp.snapdrive':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,9 +132,21 @@ class snapdrived (
   $snapcreate_check_nonpersistent_nfs        = undef,
 ){
 
-  anchor { 'snapdrived::begin': } ->
-  class { '::snapdrived::install': } ->
-  class { '::snapdrived::config': } ~>
-  class { '::snapdrived::service': } ->
-  anchor { 'snapdrived::end': }
+  package { 'netapp.snapdrive':
+    ensure => installed,
+  }
+
+
+  file { '/opt/NetApp/snapdrive/snapdrive.conf':
+    content => template('snapdrived/snapdrive.conf.erb'),
+    mode    => '0644',
+    require => Package['netapp.snapdrive'],
+  }
+
+  service { 'snapdrived':
+    ensure    => running,
+    enable    => true,
+    subscribe => File['/opt/NetApp/snapdrive/snapdrive.conf'],
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,6 +152,8 @@ class snapdrived (
     } else {
       $use_service_provider = undef
     }
+  } else {
+    $use_service_provider = $service_provider
   }
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@
 # Copyright 2016 Basler Versicherung
 #
 class snapdrived (
+  $log_dir                                   = undef,
+  $manage_log_dir                            = false,
   $path                                      = undef,
   $all_access_if_rbac_unspecified            = undef,
   $allow_partial_clone_connect               = undef,
@@ -127,6 +129,13 @@ class snapdrived (
 
   package { 'netapp.snapdrive':
     ensure => installed,
+  }
+
+  if ( $manage_log_dir && $log_dir ) {
+    file { $log_dir:
+      ensure => directory,
+      before => Service['snapdrived'],
+    }
   }
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ class snapdrived (
     ensure => installed,
   }
 
-  if ( $manage_log_dir && $log_dir ) {
+  if ( $manage_log_dir and $log_dir ) {
     file { $log_dir:
       ensure => directory,
       before => Service['snapdrived'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 # Copyright 2016 Basler Versicherung
 #
 class snapdrived (
-  $PATH                                      = undef,
+  $path                                      = undef,
   $all_access_if_rbac_unspecified            = undef,
   $allow_partial_clone_connect               = undef,
   $audit_log_file                            = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,0 @@
-class snapdrived::install {
-  package { 'netapp.snapdrive':
-    ensure => installed,
-  }
-}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,0 @@
-class snapdrived::service {
-
-  service { 'snapdrived':
-    ensure => running,
-    enable => true,
-  }
-}

--- a/templates/snapdrive.conf.erb
+++ b/templates/snapdrive.conf.erb
@@ -346,27 +346,3 @@ volume-offline-retry=<%= @volume_offline_retry %> #Number of retries during volu
 <%- if @volume_offline_retry_sleep -%>
 volume-offline-retry-sleep=<%= @volume_offline_retry_sleep %> #Number of seconds between retries during volume-offline. Data ONTAP 7-Mode only
 <%- end -%>
-<%- if @ping_interfaces_with_same_octet -%>
-ping-interfaces-with-same-octet="<%= @ping_interfaces_with_same_octet %>" #SDU only pings through host interface which has first 3 octets of IPV4 in common with filer interface
-<%- end -%>
-<%- if @snapcreate_check_nonpersistent_nfs -%>
-snapcreate-check-nonpersistent-nfs="<%= @enapcreate_check_nonpersistent_nfs %>" #Check that entries exist in persistent filesystem file for specified nfs fs.
-<%- end -%>
-<%- if @audit_log_file -%>
-audit-log-file="<%= @audit_log_file %>" #Audit Log File Path
-<%- end -%>
-<%- if @client_trace_log_file -%>
-client-trace-log-file="<%= @client_trace_log_file %>" #client trace log file (Probably never used or useful)
-<%- end -%>
-<%- if @daemon_trace_log_file -%>
-daemon-trace-log-file="<%= @daemon_trace_log_file %>" #daemon trace log file
-<%- end -%>
-<%- if @recovery_log_file -%>
-recovery-log-file="<%= @recovery_log_file %>" #recovery log file
-<%- end -%>
-<%- if @trace_log_file -%>
-trace-log-file="<%= @trace_log_file %>" #trace log file
-<%- end -%>
-<%- if @check_export_permission_nfs_clone -%>
-check-export-permission-nfs-clone="<%= @check_export_permission_nfs_clone %>" #Checks if the host has nfs export permissions for resource being connected !!!!! NEU für C-MODE
-<%- end -%>

--- a/templates/snapdrive.conf.erb
+++ b/templates/snapdrive.conf.erb
@@ -16,8 +16,8 @@
 #     -- Also remember to restart the snapdrive daemon by issuing 'snapdrived restart'
 #
 #
-<%- if @PATH -%>
-PATH="<%= @PATH %>" #toolset search path
+<%- if @path -%>
+PATH="<%= @path %>" #toolset search path
 <%- end -%>
 <%- if @all_access_if_rbac_unspecified -%>
 all-access-if-rbac-unspecified="<%= @all_access_if_rbac_unspecified %>" #Allows access to all filer operations if the RBAC permissions file is missing in filer volume


### PR DESCRIPTION
This is a refactor that fixes several issues....
#### Scoping method not supported in Puppet >3.6

The template currently tries to resolve variables as @foo, but the template is being included in the config class.  This currently works because of the scoping behaviour of Puppet 3.6 but as from 3.8 this will break since @foo is not in the scope of snapdrived::config.    Since the module is fairly straightforward I've consolidated everything into one class so the base class parameters are in the same scope as the template
#### Duplicate parameters

Many parameters were duplicated both in the class and the template, plus one was missing from class.
#### Optional log directory creation

If you change the location of the default log files then snapdrive will not create them, I've added an optional flag to manage the log directory
#### Changed PATH to path

upper case variables should not be used in Puppet
#### Added parameter to override service provider

Snapdrive seems to install only /etc/init.d files which seem incompatible with systemd - I cannot start the service with systemd but I can with service. Therefore I've added some logic to change the service provider to redhat on CentOS/RedHat 7 systems - but this is overridable with the service_provider parameter
