### PR TITLE
Feature/systemd

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,9 +165,9 @@ class snapdrived (
         }
 
         # Create unit file for systemd based system
-        file { '/usr/lib/systemd/system/snapdrived.service':
+        systemd::unit_file { 'snapdrived.service':
           content => template('snapdrived/snapdrived.service'),
-          mode    => '0644',
+          before  => Service['snapdrived'],
         }
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,8 @@
 # Copyright 2016 Basler Versicherung
 #
 class snapdrived (
+  $package_name                              = 'netapp.snapdrive',
+  $package_version                           = 'installed',
   $log_dir                                   = undef,
   $manage_log_dir                            = false,
   $path                                      = undef,
@@ -127,8 +129,8 @@ class snapdrived (
   $volume_offline_retry_sleep                = undef,
 ){
 
-  package { 'netapp.snapdrive':
-    ensure => installed,
+  package { $package_name:
+    ensure => $package_version,
   }
 
   # Create log file directory if we specify manage_log_dir

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem":"RedHat",
-      "operatingsystemrelease":[ 
+      "operatingsystemrelease":[
         "6",
         "7"
       ]
@@ -20,6 +20,10 @@
     {
       "name": "puppetlabs-stdlib",
       "version_range": ">= 1.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">=0.2.2 <1.0.0"
     }
   ]
 }


### PR DESCRIPTION
Use camptocamp/systemd to manage the systemd service file, this also takes care of reloading the daemon and puts the file in the correct location (/etc, not /usr/lib)
